### PR TITLE
fix(pos): enforce field allow-list and limit on product search API

### DIFF
--- a/src/app/api/products/search/route.ts
+++ b/src/app/api/products/search/route.ts
@@ -1,16 +1,38 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 
+// Explicit field allow-list — never expose cost, supplierId, or timestamps
+// to this client-facing endpoint.
+const PRODUCT_SELECT = {
+  id: true,
+  name: true,
+  price: true,
+  stock: true,
+  sku: true,
+  barcode: true,
+  category: true,
+  imageUrl: true,
+} as const;
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 200;
+
+function parseLimit(req: NextRequest): number {
+  const raw = Number(req.nextUrl.searchParams.get("limit"));
+  if (!Number.isFinite(raw) || raw <= 0) return DEFAULT_LIMIT;
+  return Math.min(raw, MAX_LIMIT);
+}
+
 export async function GET(req: NextRequest) {
   const q = req.nextUrl.searchParams.get("q") ?? "";
+  const take = parseLimit(req);
 
   if (!q.trim()) {
     const products = await prisma.product.findMany({
-      where: {
-        active: true
-      },
-      orderBy: {name: "asc"}
-
+      where: { active: true },
+      select: PRODUCT_SELECT,
+      orderBy: { name: "asc" },
+      take,
     });
     return NextResponse.json(
       products.map((p: typeof products[number]) => ({ ...p, price: parseFloat(p.price.toString()) }))
@@ -26,15 +48,8 @@ export async function GET(req: NextRequest) {
         { barcode: { equals: q } },
       ],
     },
-    select: {
-      id: true,
-      name: true,
-      price: true,
-      stock: true,
-      sku: true,
-      barcode: true,
-    },
-    take: 20,
+    select: PRODUCT_SELECT,
+    take,
     orderBy: { name: "asc" },
   });
 

--- a/src/components/pos/product-search.tsx
+++ b/src/components/pos/product-search.tsx
@@ -198,22 +198,20 @@ export function ProductSearch() {
                   )}
                 >
                   <div className="flex w-full items-start justify-between gap-1">
-                    
                     <p className="text-xs font-semibold leading-tight line-clamp-2 flex-1">
                       {p.name}
                     </p>
                     <Plus className="h-3.5 w-3.5 shrink-0 text-muted-foreground mt-0.5" />
                   </div>
                   {p.imageUrl ? (
-                      <div className="flex w-full justify-center">
-                     <img
-                      src={p.imageUrl} 
-                      alt="Product preview" 
-                      className="rounded-md object-cover" 
-                    />
+                    <div className="flex w-full justify-center">
+                      <img
+                        src={p.imageUrl}
+                        alt={p.name}
+                        className="rounded-md object-cover"
+                      />
                     </div>
-                    ):("")}
-
+                  ) : null}
                   <div className="flex w-full items-end justify-between mt-1.5">
                     <span className="text-sm font-bold text-primary">
                       {formatCurrency(p.price)}


### PR DESCRIPTION
## Follow-up to #5

The empty-query fix in #5 (product grid showing nothing when no active search) introduced two regressions on ` GET /api/products/search `:

1. **Unbounded query** — the empty-query branch had no ` take ` limit, so it fetched the *entire* active product catalog on every POS page load, ignoring the ` limit ` query param the frontend already sends (` ?q=&limit=60 `, ` ?q=&limit=200 ` from ` seedProductCache `).
2. **Sensitive field leakage** — that branch had no ` select `, so it returned every ` Product ` column including ` cost ` (purchase price/margin), ` supplierId `, and timestamps to any authenticated session (including cashier-role users), unlike the sibling search branch which explicitly whitelists safe fields.

### Changes
- Added a shared ` PRODUCT_SELECT ` allow-list (` id, name, price, stock, sku, barcode, category, imageUrl `) used by both branches.
- Added ` parseLimit() ` to read/validate the ` limit ` query param (default 20, capped at 200).
- Included ` imageUrl `/` category ` in both branches so thumbnails render consistently while browsing and while searching.
- Minor JSX cleanup in ` product-search.tsx ` (stray blank line, ` null ` instead of empty string for the conditional thumbnail).

### Testing
- Verified ` /pos ` grid loads with bounded result count via Network tab.
- Verified response JSON no longer includes ` cost `/` supplierId `/timestamps.
- Verified thumbnails render both in the idle grid and while typing a search query.
- ` pnpm test --run ` unit suite passes.